### PR TITLE
chore: fix Containerfile and build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,9 +1,8 @@
 FROM scratch as builder
-COPY packages/backend/dist/ /extension/dist
-COPY packages/backend/package.json /extension/
-COPY packages/backend/media/ /extension/media
+COPY dist/ /extension/dist
+COPY package.json /extension/
 COPY LICENSE /extension/
-COPY packages/backend/icon.png /extension/
+COPY icon.png /extension/
 COPY README.md /extension/
 
 FROM scratch

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,17 @@
 {
   "compilerOptions": {
-    "strict":true,
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "lib": ["ES2020", "webworker"],
     "sourceMap": true,
+    "rootDir": "src",
     "outDir": "dist",
-    "types": [
-      "node",
-    ],
+    "skipLibCheck": true,
+    "types": ["node"],
+    "strictNullChecks": true,
+    "allowSyntheticDefaultImports": true
   },
-  "include": [
-    "src",
-  ],
+  "include": ["src"]
 }


### PR DESCRIPTION
chore: fix Containerfile and build

* Fixes the Containerfile
* Fixes building the actual extension and using it

Steps to test:

1. npm run build
2. pnpm watch --extension-folder ../podman-desktop-extension-minimal-template
3. Build the containerfile
4. Install to Podman Desktop

Confirm all of the above works

Closes https://github.com/podman-desktop/extension-template-webview/issues/2

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
